### PR TITLE
feat: merge price chart service and controller

### DIFF
--- a/src/aggregators/aggregators.module.ts
+++ b/src/aggregators/aggregators.module.ts
@@ -7,15 +7,18 @@ import { BlockchainConnectorsModule } from "../blockchain-connectors/blockchain-
 import { ArrakisOperationsHelperService } from "./operations-aggregator/operations-aggregator-helpers/arrakis-operations-helper.service";
 import { ContractConnectorsModule } from "../contract-connectors/contract-connectors.module";
 import { WeweConfigModule } from "../config/wewe-data-aggregator-config.module";
+import { PriceAggregatorService } from "./price-aggregator/price-aggregator.service";
+import { PriceOraclesModule } from "../price-oracles/price-oracles.module";
 
 @Module({
-  imports: [WeweConfigModule, DatabaseModule, BlockchainConnectorsModule, ContractConnectorsModule],
+  imports: [WeweConfigModule, DatabaseModule, BlockchainConnectorsModule, ContractConnectorsModule, PriceOraclesModule],
   providers: [
     Logger,
     AggregatorsService,
     OperationsAggregatorService,
     VaultAggregatorService,
     ArrakisOperationsHelperService,
+    PriceAggregatorService,
   ],
   exports: [AggregatorsService],
 })

--- a/src/aggregators/aggregators.service.ts
+++ b/src/aggregators/aggregators.service.ts
@@ -1,12 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { OperationsAggregatorService } from "./operations-aggregator/operations-aggregator.service";
 import { VaultAggregatorService } from "./vault-aggregator/vault-aggregator.service";
+import { PriceAggregatorService } from "./price-aggregator/price-aggregator.service";
 
 @Injectable()
 export class AggregatorsService {
   constructor(
     private operationsAggregatorService: OperationsAggregatorService,
     private vaultAggregatorService: VaultAggregatorService,
+    private priceAggregatorService: PriceAggregatorService,
     private logger: Logger,
   ) {}
 
@@ -17,6 +19,10 @@ export class AggregatorsService {
     });
     this.vaultAggregatorService.startAggregating().catch((e) => {
       this.logger.error("vaultAggregatorService.startAggregating failed..");
+      throw e;
+    });
+    this.priceAggregatorService.startAggregating().catch((e) => {
+      this.logger.error("priceAggregatorService.startAggregating failed..");
       throw e;
     });
   }

--- a/src/aggregators/price-aggregator/price-aggregator.service.ts
+++ b/src/aggregators/price-aggregator/price-aggregator.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { DateTime } from "luxon";
+import { MAX_CONSECUTIVE_RETRY, ONE_HOUR_IN_MILLISECONDS, TEN_SECONDS_IN_MILLISECONDS } from "../../shared/constants";
+import { MergeCoinConfig } from "../../shared/class/WeweDataAggregatorConfig";
+import { constructTimestamps } from "../../utils/aggregation-utils";
+import { scheduleToTheNextFullHour } from "../../utils/utils";
+import { WeweConfigService } from "../../config/wewe-data-aggregator-config.service";
+import { CoingeckoService } from "../../price-oracles/coingecko/coingecko.service";
+import { PriceDbService } from "../../database/price-db/price-db.service";
+import { PriceHistoricalDataDto, PriceHistoricalMetadataDto } from "../../shared/class/PriceHistoricalDataDto";
+
+@Injectable()
+export class PriceAggregatorService {
+  private readonly logger = new Logger(PriceAggregatorService.name);
+
+  // counter responsible for adding up consecutive failures until we hit max limit
+  private consecutiveFailCount = 0;
+
+  constructor(
+    private priceDbService: PriceDbService,
+    private configService: WeweConfigService,
+    private coingeckoService: CoingeckoService,
+  ) {}
+
+  public async startAggregating(): Promise<void> {
+    if (this.configService.mergeCoinNames.length > 0) {
+      this.startHourlyPriceHistoricalAggregation();
+    }
+  }
+
+  private async startHourlyPriceHistoricalAggregation(): Promise<void> {
+    // start aggregation for each coin
+    try {
+      // concurrently sync all coin data
+      await Promise.all(this.configService.mergeCoinConfigs.map(async (coin) => this.aggregatePriceData(coin)));
+
+      // reset consecutiveFailCount if aggregation succeeded
+      this.consecutiveFailCount = 0;
+
+      // if all coins are synced, schedule next sync at next full hour
+      scheduleToTheNextFullHour(() => this.startAggregating());
+    } catch (e) {
+      this.consecutiveFailCount++;
+
+      // if aggregation failed more than <MAX_CONSECUTIVE_RETRY> times in a row, throw an error because something is very wrong
+      if (this.consecutiveFailCount > MAX_CONSECUTIVE_RETRY) {
+        throw e;
+      }
+
+      this.logger.error(`Aggregation failed with error ${JSON.stringify(e, null, 2)}. Retrying in 10 seconds..`);
+
+      // catch error and retry aggregation in 10 seconds
+      setTimeout(() => this.startAggregating(), TEN_SECONDS_IN_MILLISECONDS);
+    }
+  }
+
+  private async aggregatePriceData(coinConfig: MergeCoinConfig): Promise<void> {
+    // retrieve last time when aggregation happened
+    let lastTimestampAggregated: number | bigint | undefined =
+      await this.priceDbService.getMostRecentPriceDataTimestamp(coinConfig.memeCoingeckoName);
+
+    if (lastTimestampAggregated == undefined) {
+      // if there is no last timestamp, derive the first timestamp from the starting block
+      lastTimestampAggregated = coinConfig.chartStartTimestamp;
+    }
+
+    this.logger.debug(`${coinConfig.memeCoingeckoName} - lastTimestampAggregated: ${lastTimestampAggregated}`);
+
+    // calculate next hour from the last aggregation timestamp e.g.
+    const startingHourToAggregateFrom: number = DateTime.fromMillis(Number(lastTimestampAggregated))
+      .plus({ hour: 1 })
+      .startOf("hour")
+      .toMillis();
+
+    const now: DateTime = DateTime.local();
+
+    const hourlyTimestampsToProcess = constructTimestamps(
+      startingHourToAggregateFrom,
+      now.toMillis(),
+      ONE_HOUR_IN_MILLISECONDS,
+    );
+
+    for (const timestamp of hourlyTimestampsToProcess) {
+      const price = await this.coingeckoService.getTokenUsdPrice(coinConfig.memeCoingeckoName, timestamp);
+
+      // save into DB
+      await this.priceDbService.savePriceData(
+        new PriceHistoricalDataDto(
+          new Date(timestamp),
+          new PriceHistoricalMetadataDto(coinConfig.memeCoingeckoName, +price),
+        ),
+      );
+
+      this.logger.log(`Saved price ${coinConfig.memeCoingeckoName} data for ${DateTime.fromMillis(timestamp).toISO()}`);
+    }
+  }
+}

--- a/src/api/merge/merge.controller.spec.ts
+++ b/src/api/merge/merge.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { MergeController } from "./merge.controller";
+
+describe("MergeController", () => {
+  let controller: MergeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MergeController],
+    }).compile();
+
+    controller = module.get<MergeController>(MergeController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/api/merge/merge.controller.ts
+++ b/src/api/merge/merge.controller.ts
@@ -1,0 +1,69 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Logger,
+  NotFoundException,
+  Param,
+  Query,
+  UsePipes,
+  ValidationPipe,
+} from "@nestjs/common";
+import { MergeService } from "./merge.service";
+import { ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
+import { MergeChartDatapoint } from "../../dto/MergeChartDto";
+import { GetMergeChartParamsDto } from "../../dto/GetMergeChartParamsDto";
+import { HistoricDataQueryParamsDto } from "../../dto/HistoricDataQueryParamsDto";
+
+@Controller("merge")
+export class MergeController {
+  private readonly logger = new Logger(MergeController.name);
+
+  constructor(private readonly mergeService: MergeService) {}
+
+  @Get("/:coinId")
+  @ApiOperation({
+    summary: "Get Merge chart for a specific coin",
+    description: "Retrieve chart information for WEWE and the to be merged coin.",
+  })
+  @ApiParam({
+    name: "coinId",
+    type: "string",
+    description: "Name of the merge coin",
+    example: "brokkr",
+  })
+  @ApiQuery({
+    name: "timeframe",
+    required: false,
+    type: String,
+    enum: ["daily", "weekly", "monthly"],
+    description: "Timeframe for historic chart data.",
+    example: "daily",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Successfully retrieved chart information.",
+    type: [MergeChartDatapoint],
+  })
+  @ApiNotFoundResponse({
+    description: "Merge Coin not found",
+  })
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      exceptionFactory: (errors) => new BadRequestException(`Bad Request: ${errors}`),
+    }),
+  )
+  async getMergeChart(
+    @Param() params: GetMergeChartParamsDto,
+    @Query() queryParams: HistoricDataQueryParamsDto,
+  ): Promise<MergeChartDatapoint[]> {
+    const { coinId } = params;
+    try {
+      return await this.mergeService.getMergeChart(coinId.toLowerCase(), queryParams.timeframe);
+    } catch (error) {
+      this.logger.error(`Error fetching merge chart information for coin ${coinId}: ${error}`);
+      throw new NotFoundException("Merge Coin not found");
+    }
+  }
+}

--- a/src/api/merge/merge.controller.ts
+++ b/src/api/merge/merge.controller.ts
@@ -43,7 +43,8 @@ export class MergeController {
   @ApiResponse({
     status: 200,
     description: "Successfully retrieved chart information.",
-    type: [MergeChartDatapoint],
+    type: MergeChartDatapoint,
+    isArray: true,
   })
   @ApiNotFoundResponse({
     description: "Merge Coin not found",

--- a/src/api/merge/merge.module.ts
+++ b/src/api/merge/merge.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { MergeService } from "./merge.service";
+import { MergeController } from "./merge.controller";
+import { DatabaseModule } from "../../database/database.module";
+import { WeweConfigModule } from "../../config/wewe-data-aggregator-config.module";
+
+@Module({
+  imports: [DatabaseModule, WeweConfigModule],
+  providers: [MergeService],
+  controllers: [MergeController],
+})
+export class MergeModule {}

--- a/src/api/merge/merge.service.spec.ts
+++ b/src/api/merge/merge.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { MergeService } from "./merge.service";
+
+describe("MergeService", () => {
+  let service: MergeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MergeService],
+    }).compile();
+
+    service = module.get<MergeService>(MergeService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/api/merge/merge.service.ts
+++ b/src/api/merge/merge.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { MergeChartDatapoint } from "../../dto/MergeChartDto";
+import { PriceDbService } from "../../database/price-db/price-db.service";
+import { WEWE_COINGECKO_NAME } from "../../shared/constants";
+import { getStartDateFromNow } from "../../utils/utils";
+import { TimeFrame } from "../../dto/HistoricDataQueryParamsDto";
+import { WeweConfigService } from "../../config/wewe-data-aggregator-config.service";
+
+@Injectable()
+export class MergeService {
+  private readonly logger = new Logger(MergeService.name);
+
+  constructor(
+    private readonly priceDbService: PriceDbService,
+    private readonly configService: WeweConfigService,
+  ) {}
+
+  public async getMergeChart(coinId: string, timeFrame: TimeFrame): Promise<MergeChartDatapoint[]> {
+    if (!this.configService.mergeCoinNames.includes(coinId)) {
+      throw new NotFoundException("Coin Id not found");
+    }
+
+    const startDate = getStartDateFromNow(timeFrame);
+    const wewePricePoints = await this.priceDbService.getPricePointsOfToken(WEWE_COINGECKO_NAME, startDate);
+    const mergeCoinPricePoints = await this.priceDbService.getPricePointsOfToken(coinId, startDate);
+
+    // Create a map for merge coin prices indexed by timestamp for quick lookup
+    const mergeCoinPriceMap: Map<number, number> = new Map();
+    mergeCoinPricePoints.forEach((point) => {
+      mergeCoinPriceMap.set(point.timestamp, point.price);
+    });
+
+    // Merge the data based on timestamps
+    const mergedChartData: MergeChartDatapoint[] = wewePricePoints
+      .map((wewePoint) => {
+        const mergeCoinPrice = mergeCoinPriceMap.get(wewePoint.timestamp);
+
+        // Handle cases where there might not be a corresponding merge coin price
+        if (mergeCoinPrice === undefined) {
+          // Log and skip the datapoint
+          this.logger.error(`No ${coinId} price found for timestamp ${wewePoint.timestamp}`);
+          return null;
+        }
+
+        return new MergeChartDatapoint(wewePoint.timestamp, wewePoint.price, mergeCoinPrice);
+      })
+      .filter((datapoint) => datapoint !== null) as MergeChartDatapoint[];
+
+    return mergedChartData;
+  }
+}

--- a/src/api/vaults/vaults.controller.ts
+++ b/src/api/vaults/vaults.controller.ts
@@ -97,7 +97,8 @@ export class VaultsController {
   @ApiResponse({
     status: 200,
     description: "Successfully retrieved historic TVL data.",
-    type: [HistoricTvlDatapoint],
+    type: HistoricTvlDatapoint,
+    isArray: true,
   })
   @ApiBadRequestResponse({
     description: "Bad Request - Invalid parameters.",
@@ -146,7 +147,8 @@ export class VaultsController {
   @ApiResponse({
     status: 200,
     description: "Successfully retrieved historic price data.",
-    type: [HistoricPriceDatapoint],
+    type: HistoricPriceDatapoint,
+    isArray: true,
   })
   @ApiBadRequestResponse({
     description: "Bad Request - Invalid parameters.",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { MongooseModule } from "@nestjs/mongoose";
 import { VaultsModule } from "./api/vaults/vaults.module";
 import { WeweConfigModule } from "./config/wewe-data-aggregator-config.module";
 import { WeweConfigService } from "./config/wewe-data-aggregator-config.service";
+import { MergeModule } from "./api/merge/merge.module";
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { WeweConfigService } from "./config/wewe-data-aggregator-config.service"
       inject: [WeweConfigService],
     }),
     VaultsModule,
+    MergeModule,
   ],
   controllers: [AppController],
   providers: [AppService, Logger],

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -15,6 +15,7 @@ const config: Record<string, unknown> = {
   arrakisVaults: JSON.parse(process.env.ARRAKIS_VAULTS ?? ""),
   arrakisHelperAddress: process.env.ARRAKIS_HELPER_ADDRESS,
   feeManagerAddress: process.env.FEE_MANAGER_ADDRESS,
+  mergeCoins: JSON.parse(process.env.MERGE_COINS ?? ""),
 };
 
 export default registerAs("config", () => {

--- a/src/config/wewe-data-aggregator-config.service.ts
+++ b/src/config/wewe-data-aggregator-config.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Address } from "viem";
-import { ArrakisVaultConfig, WeweConfig } from "../shared/class/WeweDataAggregatorConfig";
+import { ArrakisVaultConfig, MergeCoinConfig, WeweConfig } from "../shared/class/WeweDataAggregatorConfig";
 import { MongoConfig } from "../shared/class/MongoConfig";
 
 @Injectable()
@@ -97,5 +97,13 @@ export class WeweConfigService {
 
   get arrakisVaultsAddresses(): Address[] {
     return this.config.arrakisVaults.map((v) => v.address);
+  }
+
+  get mergeCoinConfigs(): MergeCoinConfig[] {
+    return this.config.mergeCoins;
+  }
+
+  get mergeCoinNames(): string[] {
+    return this.config.mergeCoins.map((v) => v.memeCoingeckoName);
   }
 }

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -6,6 +6,8 @@ import { VaultHistoricalDocument, VaultsHistoricalDocumentSchema } from "./schem
 import { WeweConfigModule } from "../config/wewe-data-aggregator-config.module";
 import { ProgressMetadataDocument, ProgressMetadataSchema } from "./schemas/ProgressMetadata";
 import { ProgressMetadataDbService } from "./progress-metadata/progress-metadata-db.service";
+import { PriceHistoricalDocument, PriceHistoricalDocumentSchema } from "./schemas/PriceHistoricalData.schema";
+import { PriceDbService } from "./price-db/price-db.service";
 
 @Module({
   imports: [
@@ -22,10 +24,14 @@ import { ProgressMetadataDbService } from "./progress-metadata/progress-metadata
         name: ProgressMetadataDocument.name,
         schema: ProgressMetadataSchema,
       },
+      {
+        name: PriceHistoricalDocument.name,
+        schema: PriceHistoricalDocumentSchema,
+      },
     ]),
     WeweConfigModule,
   ],
-  providers: [Logger, VaultDbService, ProgressMetadataDbService],
-  exports: [VaultDbService, ProgressMetadataDbService],
+  providers: [Logger, VaultDbService, ProgressMetadataDbService, PriceDbService],
+  exports: [VaultDbService, ProgressMetadataDbService, PriceDbService],
 })
 export class DatabaseModule {}

--- a/src/database/price-db/price-db.service.ts
+++ b/src/database/price-db/price-db.service.ts
@@ -7,10 +7,9 @@ import { PriceHistoricalDataDto } from "../../shared/class/PriceHistoricalDataDt
 
 @Injectable()
 export class PriceDbService {
-  constructor(
-    @InjectModel(PriceHistoricalDocument.name) private priceDataModel: Model<PriceHistoricalDocument>,
-    private readonly logger: Logger,
-  ) {}
+  private readonly logger = new Logger(PriceDbService.name);
+
+  constructor(@InjectModel(PriceHistoricalDocument.name) private priceDataModel: Model<PriceHistoricalDocument>) {}
 
   public async getMostRecentPriceDataTimestamp(coinId: string): Promise<number | undefined> {
     const priceHistoricalData: PriceHistoricalDataDocument[] | undefined = await this.priceDataModel

--- a/src/database/price-db/price-db.service.ts
+++ b/src/database/price-db/price-db.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model } from "mongoose";
+import { HistoricPriceDatapoint } from "../../dto/HistoricPriceDto";
+import { PriceHistoricalDataDocument, PriceHistoricalDocument } from "../schemas/PriceHistoricalData.schema";
+import { PriceHistoricalDataDto } from "../../shared/class/PriceHistoricalDataDto";
+
+@Injectable()
+export class PriceDbService {
+  constructor(
+    @InjectModel(PriceHistoricalDocument.name) private priceDataModel: Model<PriceHistoricalDocument>,
+    private readonly logger: Logger,
+  ) {}
+
+  public async getMostRecentPriceDataTimestamp(coinId: string): Promise<number | undefined> {
+    const priceHistoricalData: PriceHistoricalDataDocument[] | undefined = await this.priceDataModel
+      .find({
+        "metadata.coinId": coinId.toLowerCase(),
+      })
+      .sort({
+        timestamp: -1,
+      })
+      .limit(1)
+      .exec();
+
+    if (priceHistoricalData && priceHistoricalData.length > 0) {
+      return priceHistoricalData[0].timestamp.getTime();
+    } else {
+      return undefined;
+    }
+  }
+
+  public async savePriceData(entry: PriceHistoricalDataDto): Promise<boolean> {
+    this.logger.debug(`Saving price historical hourly data: ${entry.metadata.coinId}`);
+
+    try {
+      const createdPriceHistoricalData = new this.priceDataModel(entry);
+
+      return !!(await createdPriceHistoricalData.save());
+    } catch (e) {
+      // Check if the error is a duplicate key error (11000 is the MongoDB error code for duplicate key error)
+      if (e.code === 11000) {
+        this.logger.warn("Duplicate key error. Ignoring.");
+        return true;
+      } else {
+        this.logger.error(`Failed to save vault historical operation.. Error: ${JSON.stringify(e, null, 2)}`);
+
+        // Re-throw the error if it's not a duplicate key error
+        throw e;
+      }
+    }
+  }
+
+  public async getPricePointsOfToken(coinId: string, timeFrameStartDate: Date): Promise<HistoricPriceDatapoint[]> {
+    try {
+      const priceData = await this.priceDataModel
+        .aggregate([
+          {
+            $match: {
+              "metadata.coinId": coinId.toLowerCase(),
+              timestamp: { $gte: timeFrameStartDate },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              timestamp: 1,
+              price: "$metadata.price",
+            },
+          },
+        ])
+        .exec();
+
+      if (priceData.length === 0) {
+        this.logger.warn("Price Data is empty", this.getPricePointsOfToken.name);
+        return [];
+      }
+
+      return priceData.map(({ timestamp, price }) => {
+        const date = new Date(timestamp);
+        const unixTimestamp = Math.floor(date.getTime() / 1000);
+        return new HistoricPriceDatapoint(unixTimestamp, price);
+      });
+    } catch (error) {
+      this.logger.error("Error fetching Price points", this.getPricePointsOfToken.name, error);
+      throw error;
+    }
+  }
+}

--- a/src/database/schemas/PriceHistoricalData.schema.ts
+++ b/src/database/schemas/PriceHistoricalData.schema.ts
@@ -1,0 +1,42 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, HydratedDocument } from "mongoose";
+@Schema({
+  _id: false,
+})
+export class PriceHistoricalMetadata extends Document {
+  @Prop({
+    type: String,
+    isRequired: true,
+    lowercase: true,
+  })
+  coinId: string;
+
+  @Prop({ isRequired: true })
+  price: number;
+}
+
+export const PriceHistoricalMetadataSchema = SchemaFactory.createForClass(PriceHistoricalMetadata);
+
+@Schema({
+  collection: "priceData",
+  autoCreate: true,
+  autoIndex: true,
+})
+export class PriceHistoricalDocument extends Document {
+  @Prop({
+    type: Date,
+    isRequired: true,
+  })
+  timestamp: Date; // The primary date field for time series data
+
+  @Prop({
+    type: PriceHistoricalMetadataSchema,
+    isRequired: true,
+  })
+  metadata: PriceHistoricalMetadata;
+}
+
+export type PriceHistoricalDataDocument = HydratedDocument<PriceHistoricalDocument>;
+
+export const PriceHistoricalDocumentSchema = SchemaFactory.createForClass(PriceHistoricalDocument);
+PriceHistoricalDocumentSchema.index({ timestamp: 1, "metadata.coinId": 1 }, { unique: true });

--- a/src/dto/GetMergeChartParamsDto.ts
+++ b/src/dto/GetMergeChartParamsDto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class GetMergeChartParamsDto {
+  @ApiProperty({
+    description: "Name of the merge coin",
+    example: "brokkr",
+  })
+  coinId: string;
+}

--- a/src/dto/HistoricDataQueryParamsDto.ts
+++ b/src/dto/HistoricDataQueryParamsDto.ts
@@ -3,6 +3,7 @@ import { IsEnum } from "class-validator";
 export enum TimeFrame {
   Daily = "daily",
   Weekly = "weekly",
+  Monthly = "monthly",
 }
 
 export class HistoricDataQueryParamsDto {

--- a/src/dto/MergeChartDto.ts
+++ b/src/dto/MergeChartDto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class MergeChartDatapoint {
+  @ApiProperty({
+    description: "UNIX timestamp in seconds",
+    example: 1725235621,
+    type: Number,
+  })
+  timestamp: number;
+
+  @ApiProperty({
+    description: "WEWE tokenprice",
+    example: 4.612,
+    type: Number,
+  })
+  wewePrice: number;
+
+  @ApiProperty({
+    description: "Token price for merge coin",
+    example: 2.123,
+    type: Number,
+  })
+  mergeCoinPrice: number;
+
+  constructor(timestamp: number, wewePrice: number, mergeCoinPrice: number) {
+    this.timestamp = timestamp;
+    this.wewePrice = wewePrice;
+    this.mergeCoinPrice = mergeCoinPrice;
+  }
+}

--- a/src/shared/class/PriceHistoricalDataDto.ts
+++ b/src/shared/class/PriceHistoricalDataDto.ts
@@ -1,0 +1,19 @@
+export class PriceHistoricalMetadataDto {
+  coinId: string;
+  price: number;
+
+  constructor(coinId: string, price: number) {
+    this.coinId = coinId;
+    this.price = price;
+  }
+}
+
+export class PriceHistoricalDataDto {
+  timestamp: Date;
+  metadata: PriceHistoricalMetadataDto;
+
+  constructor(timestamp: Date, metadata: PriceHistoricalMetadataDto) {
+    this.timestamp = timestamp;
+    this.metadata = metadata;
+  }
+}

--- a/src/shared/class/WeweDataAggregatorConfig.ts
+++ b/src/shared/class/WeweDataAggregatorConfig.ts
@@ -55,6 +55,21 @@ export class TokenConfig {
   }
 }
 
+export class MergeCoinConfig {
+  @IsString()
+  @IsNotEmpty()
+  memeCoingeckoName: string;
+
+  @IsNumber()
+  @Min(0)
+  chartStartTimestamp: number;
+
+  constructor(memeCoingeckoName: string, chartStartTimestamp: number) {
+    this.memeCoingeckoName = memeCoingeckoName;
+    this.chartStartTimestamp = chartStartTimestamp;
+  }
+}
+
 export class WeweConfig {
   @IsString()
   @IsNotEmpty()
@@ -89,17 +104,24 @@ export class WeweConfig {
   @IsEthereumAddress({ each: true })
   feeManagerAddress: string;
 
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MergeCoinConfig)
+  mergeCoins: MergeCoinConfig[];
+
   constructor(
     nodeUrlRpc: string,
     mongoConfig: MongoConfig,
     arrakisVaults: ArrakisVaultConfig[],
     arrakisHelperAddress: string,
     feeManagerAddress: string,
+    mergeCoins: MergeCoinConfig[],
   ) {
     this.nodeUrlRpc = nodeUrlRpc;
     this.mongoConfig = mongoConfig;
     this.arrakisVaults = arrakisVaults;
     this.arrakisHelperAddress = arrakisHelperAddress;
     this.feeManagerAddress = feeManagerAddress;
+    this.mergeCoins = mergeCoins;
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -27,3 +27,5 @@ export const LP_PRESENTATION_DECIMALS = 4;
 export const COINGECKO_MAX_DAYS_FOR_HOURLY_DATA = 89;
 
 export const MAX_CONSECUTIVE_RETRY = 10;
+
+export const WEWE_COINGECKO_NAME = "upside-down-meme";

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -53,6 +53,9 @@ export function getStartDateFromNow(timeframe: TimeFrame): Date {
     case TimeFrame.Weekly:
       timeFrameStartDate.setDate(now.getDate() - 7);
       break;
+    case TimeFrame.Monthly:
+      timeFrameStartDate.setMonth(now.getMonth() - 1);
+      break;
   }
 
   return timeFrameStartDate;


### PR DESCRIPTION
- add price aggregator for wewe and merge coins
    - fetch from coingecko and save in db
- add /merge/{coinId} endpoint, which serves combined chart of wewe and {coinId} for up until a month back in time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `PriceAggregatorService` for aggregating cryptocurrency price data.
  - Added `MergeController` and `MergeService` to handle merge chart requests.
  - New `MergeModule` organizes merge-related operations.
  - Added support for a new `Monthly` timeframe option in data queries.

- **Bug Fixes**
  - Enhanced error handling for price aggregation failures.

- **Documentation**
  - Created unit tests for `MergeController` and `MergeService`.

- **Chores**
  - Updated configuration to include merge coin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->