### PR TITLE
add fees per week property

### DIFF
--- a/src/api/vaults/vaults-data-provider/vaults-data-provider.ts
+++ b/src/api/vaults/vaults-data-provider/vaults-data-provider.ts
@@ -173,6 +173,23 @@ export class VaultsDataProvider {
     return await this.getTotalFeesInUsd(startTimestamp, endTimestamp);
   }
 
+  /**
+   * Calculates the total accumulated fees in USD on this week.
+   * @returns A promise that resolves to the accumulated fees in USDC.
+   */
+  public async getFeesPerWeek(): Promise<number> {
+    const endTimestamp = getEndOfPreviousDayTimestamp();
+    let startTimestamp = endTimestamp - MILLISECONDS_PER_WEEK; //weekly data
+
+    // if vault deployment is after startTimestamp, we use timestamp from startingBlock env property
+    const deploymentTimestamp = await this.getDeploymentTimestamp();
+    if (startTimestamp <= deploymentTimestamp) {
+      startTimestamp = deploymentTimestamp;
+    }
+
+    return await this.getTotalFeesInUsd(startTimestamp, endTimestamp);
+  }
+
   private async getTotalFeesInUsd(startTimestamp: number, endTimestamp: number): Promise<number> {
     const collectedFees = await this.getRewardsConvertedToUsdc(startTimestamp, endTimestamp);
 

--- a/src/api/vaults/vaults-data-provider/vaults-data-provider.ts
+++ b/src/api/vaults/vaults-data-provider/vaults-data-provider.ts
@@ -174,9 +174,16 @@ export class VaultsDataProvider {
   }
 
   /**
-   * Calculates the total accumulated fees in USD on this week.
-   * @returns A promise that resolves to the accumulated fees in USDC.
+   * Calculates the total accumulated fees in USD for the previous week period.
+   * The calculation period spans from 7 days before the end of the previous day
+   * up to the end of the previous day. For newly deployed vaults, the period
+   * starts from the deployment timestamp.
+   * @returns A promise that resolves to the accumulated fees in USDC (decimal format).
+   * @example
+   * const weeklyFees = await vaultsDataProvider.getFeesPerWeek();
+   * console.log(`Weekly fees: ${weeklyFees} USDC`);
    */
+  @MemoizeExpiring(FIVE_MINUTES_IN_MILLISECONDS)
   public async getFeesPerWeek(): Promise<number> {
     const endTimestamp = getEndOfPreviousDayTimestamp();
     let startTimestamp = endTimestamp - MILLISECONDS_PER_WEEK; //weekly data

--- a/src/api/vaults/vaults.service.ts
+++ b/src/api/vaults/vaults.service.ts
@@ -30,14 +30,15 @@ export class VaultsService {
     const feeManagerAddress = this.configService.getfeeManagerAddress(vaultAddress);
 
     try {
-      const [apr, feesPerDay, rate] = await Promise.all([
+      const [apr, feesPerDay, feesPerWeek, rate] = await Promise.all([
         vaultDataProvider.getFeeApr(),
         vaultDataProvider.getFeesPerDay(),
+        vaultDataProvider.getFeesPerWeek(),
         this.feeManagerContractService.getRate(feeManagerAddress),
       ]);
       const incentivesPerDay = feesPerDay * rate;
 
-      return new VaultInfoResponseDto(vaultAddress, apr, feesPerDay, incentivesPerDay);
+      return new VaultInfoResponseDto(vaultAddress, apr, feesPerDay, incentivesPerDay, feesPerWeek);
     } catch (error) {
       this.logger.error("Error retrieving vault info:", error);
       throw error;

--- a/src/dto/VaultInfoResponseDto.ts
+++ b/src/dto/VaultInfoResponseDto.ts
@@ -30,10 +30,18 @@ export class VaultInfoResponseDto {
   })
   incentivesPerDay: number;
 
-  constructor(address: Address, feeApr: number, feesPerDay: number, incentivesPerDay: number) {
+  @ApiProperty({
+    description: "Total fees accumulated per week in USD.",
+    example: 524,
+    type: Number,
+  })
+  feesPerWeek: number;
+
+  constructor(address: Address, feeApr: number, feesPerDay: number, incentivesPerDay: number, feesPerWeek: number) {
     this.address = address;
     this.feeApr = feeApr;
     this.feesPerDay = feesPerDay;
     this.incentivesPerDay = incentivesPerDay;
+    this.feesPerWeek = feesPerWeek;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to calculate and retrieve weekly accumulated fees in USD for vaults.
	- Enhanced the vault information retrieval to include weekly fee data alongside existing metrics.

- **Bug Fixes**
	- Improved data handling in the vault information service to ensure accurate fee reporting.

- **Documentation**
	- Updated API documentation to reflect the new `feesPerWeek` property in the VaultInfoResponseDto.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->